### PR TITLE
Soluciono elemento "justAnterior" no definido

### DIFF
--- a/view/modelo_130.html
+++ b/view/modelo_130.html
@@ -139,7 +139,7 @@
     }
 
     var justAnterior;
-    if (document.getElementById("justAnterior").value.length > 0){
+    if (document.getElementById("justAnterior") != null && document.getElementById("justAnterior").value.length > 0){
     justAnterior = "X" + document.getElementById("justAnterior").value.toString();
     } else{
     justAnterior = '              '; //justi valido prueba 1348575683542


### PR DESCRIPTION
Al generar un trimestre por primera vez si haber hecho previamente ninguno antes, este elemento no existe por lo que provoca un error que no deja continuar con el calculo del modelo. 

Lo he solucionado, verificando antes de la comprobación de valor, si existe o no el elemento justAnterior